### PR TITLE
(PR2) chore: align dependency pinning policy across all repos

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -290,6 +290,6 @@ Parameters not relevant for DC LOPF (silently ignored):
 | Component | Current Version | Version File |
 |-----------|----------------|--------------|
 | Converter | 0.0.1 | `pyproject.toml` |
-| PyPSA Models Library | 1.0.0 | `resources/pypsa_models/pypsa_models.yml` |
+| PyPSA Models Library | 2.0.1 | `resources/pypsa_models/pypsa_models.yml` |
 | PyPSA | 1.2.0 | `pyproject.toml` |
 | Antares-Simulator | 9.3.7 | `dependencies.json` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,12 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "pandas==2.2.3",
+    "pandas>=2.2.3",
     "polars>=0.20.0",
     "pyarrow",
     "pypsa==1.2.0",
-    "pyyaml==6.0.2",
-    "pydantic==2.12.5",
+    "pyyaml>=6.0.2",
+    "pydantic>=2.12.5",
 ]
 classifiers = [
     # Classifiers here: https://pypi.org/classifiers/
@@ -44,12 +44,12 @@ pypsa-to-gems = "src.cli:main"
 
 [dependency-groups]
 dev = [
-    "pytest==7.0.1",
-    "pytest-xdist==3.8.0",
+    "pytest>=7.0.1",
+    "pytest-xdist>=3.8.0",
     "highspy>=1.5.0",
-    "ruff~=0.9.6",
-    "mypy~=1.15.0",
-    "pre-commit~=4.1.0",
+    "ruff>=0.9.6",
+    "mypy>=1.15.0",
+    "pre-commit>=4.1.0",
     "pandas-stubs>=2.0.0",
     "types-PyYAML>=6.0.0",
 ]


### PR DESCRIPTION
## Process CHORE - Dependencies Policy Pinning Allignment

### Aligns dependency pinning across the GEMS ecosystem with an agreed policy:

Third-party dependencies → >= (flexible lower bound, allows patch/minor upgrades without manual bumps)
Specific/internal dependencies (antares-craft, gemspy, pypsa) → == (exact pin, ensures coordinated releases between GEMS components)

## Description

Eight changes in **pyproject.toml**:

**[project] dependencies:**

pandas==2.2.3 → >=2.2.3
pyyaml==6.0.2 → >=6.0.2
pydantic==2.12.5 → >=2.12.5


**[dependency-groups] dev:**

pytest==7.0.1 → >=7.0.1
pytest-xdist==3.8.0 → >=3.8.0
ruff~=0.9.6 → >=0.9.6
mypy~=1.15.0 → >=1.15.0
pre-commit~=4.1.0 → >=4.1.0

`FIX:` There's also an unrelated change in COMPATIBILITY.md (PyPSA Models Library version bump 1.0.0 → 2.0.1). It doesn't now affect on any workflow action at the moment !

## Checklist

- [x] Github Workflow Pass
