### PR TITLE
(PR5) Clarify GEMS library sync is a three-file copy in notify issue body

### DIFF
--- a/.github/workflows/notify-gems-pypsa-models-update.yml
+++ b/.github/workflows/notify-gems-pypsa-models-update.yml
@@ -69,9 +69,15 @@ jobs:
             const body = [
               `PyPSA models library updated to \`v${version}\` in [${converterRepo}](https://github.com/${converterOwner}/${converterRepo}).`,
               '',
-              `Changelog: https://github.com/${converterOwner}/${converterRepo}/blob/main/resources/pypsa_models/CHANGELOG-pypsa_models_library.md`,
+              'The converter is the **source of truth** for this library. To sync GEMS, simply copy the following three files from the converter into the GEMS repository — no regeneration or manual edits are required:',
               '',
-              'Update `libraries/pypsa_models.yml` in GEMS accordingly.',
+              '| File | From (converter) | To (GEMS) |',
+              '|---|---|---|',
+              '| Library YAML | `resources/pypsa_models/pypsa_models.yml` | `libraries/pypsa_models.yml` |',
+              '| SHA256 checksum | `resources/pypsa_models/pypsa_models.yml.sha256` | `libraries/pypsa_models.yml.sha256` |',
+              '| Library changelog | `resources/pypsa_models/CHANGELOG-pypsa_models_library.md` | `libraries/CHANGELOG-pypsa_models_library.md` |',
+              '',
+              'That is all — copy these three files and nothing else.',
             ].join('\n');
 
             const result = await github.rest.issues.create({


### PR DESCRIPTION
## Description

Rewrite the issue body created by the notify-GEMS workflow to spell out that syncing the library into GEMS is just copying three files from the converter (the source of truth): the library YAML, its .sha256 checksum, and the library changelog. Lists the exact source and destination paths and states that no regeneration or manual edits are required in GEMS.