### PR TITLE
feat(operational studies): introduce operational studies conversion and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pypsa==1.2.4",
     "pyyaml>=6.0.2",
     "pydantic>=2.12.5",
+    "antares-craft==0.15.1",
 ]
 classifiers = [
     # Classifiers here: https://pypi.org/classifiers/
@@ -52,7 +53,7 @@ dev = [
     "pre-commit>=4.1.0",
     "pandas-stubs>=2.0.0",
     "types-PyYAML>=6.0.0",
-    "gemspy==0.1.2",
+    "gemspy==0.1.3",
 ]
 
 [tool.setuptools.packages.find]
@@ -90,9 +91,9 @@ module = ["src.models", "src.models.gems_system_yml_schema", "src.models.modeler
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["tests.e2e.end_2_end_tests", "tests.local_benchmark.benchmark"]
+module = ["tests.e2e.end_2_end_tests", "tests.e2e.test_hybrid_study_comparison", "tests.local_benchmark.benchmark"]
 disable_error_code = ["operator"]
 
 [[tool.mypy.overrides]]
-module = ["pypsa.*", "pandas.*", "pydantic.*", "pytest.*", "gems.*"]
+module = ["pypsa.*", "pandas.*", "pydantic.*", "pytest.*", "gems_craft.*", "gems_runner.*", "gems_craft_hybrid.*", "antares.*"]
 ignore_missing_imports = true

--- a/resources/optim-config.yml
+++ b/resources/optim-config.yml
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+resolution-mode: benders-decomposition
 models:
   - id: pypsa_models.generator
     model-decomposition:

--- a/src/antares_hybrid_writer.py
+++ b/src/antares_hybrid_writer.py
@@ -81,7 +81,7 @@ class AntaresHybridStudyWriter:
     def write(self, gems_systems_dir: Path, pypsa_network: Network, n_scenarios: int) -> Path:
         """Build the hybrid study and return its directory (self.study_dir / self.study_name)."""
         antares_study_dir = self._build_virtual_antares_study(pypsa_network, n_scenarios)
-        self._install_gems_system(antares_study_dir, gems_systems_dir, n_scenarios)
+        self._add_gems_system(antares_study_dir, gems_systems_dir, n_scenarios)
         return antares_study_dir
 
     def _build_virtual_antares_study(self, pypsa_network: Network, n_scenarios: int) -> Path:

--- a/src/antares_hybrid_writer.py
+++ b/src/antares_hybrid_writer.py
@@ -22,8 +22,7 @@ Monte-Carlo years / generaldata.ini: it silently only ever solves scenario 0,
 regardless of how many scenarios the PyPSA/GEMS study actually declares.
 
 antares-solver (the real Antares engine) does understand Monte-Carlo years, but it
-only understands classic Antares studies (areas/links/thermal clusters) -- it has no
-notion of a GEMS system on its own.
+only understands classic Antares studies (areas/links/thermal clusters) -- it has no notion of a GEMS system on its own.
 This writer builds a "hybrid" study to get the best of both, validated end-to-end in tests/e2e/test_hybrid_study_comparison.py:
 
 1. Create a bare-bones classic Antares study with antares-craft, containing a single
@@ -34,23 +33,21 @@ This writer builds a "hybrid" study to get the best of both, validated end-to-en
    objective value in any way.
 2. Copy the converted GEMS system (system.yml, model-libraries/, data-series/)
    directly into the classic study's own input/ directory. antares-solver's hybrid
-   loader reads input/system.yml relative to the Antares study root -- confirmed
-   empirically by inspecting its own log output (System loaded, Data-series
-   loaded") and by grepping the binary for the literal string "system.yml".
+   loader reads input/system.yml relative to the Antares study root
 3. Set nb_years (Monte-Carlo years) in generaldata.ini, via antares-craft, to the
    number of scenarios declared by the GEMS/PyPSA study, so Antares' own MC-year loop
    lines up with the GEMS scenario axis.
-4. Add `resolution-mode: benders-decomposition` to `optim-config.yml`. This is required
-   by `antares-solver`'s hybrid loader for ANY model with an investment-style variable --
-   even non-extendable (`p_nom_extendable=False`) generators declare `p_nom` as a
-   "master-and-subproblems" decomposition variable in `pypsa_models.yml` (see
-   `resources/optim-config.yml`) -- so this applies even though this writer is only
-   ever invoked for non-investment studies (see `PyPSAStudyConverter._has_extendable_capacity`).
+4. Add resolution-mode: benders-decomposition to optim-config.yml. This is required
+   by antares-solver's hybrid loader for ANY model with an investment-style variable --
+   even non-extendable (p_nom_extendable=False) generators declare p_nom as a
+   "master-and-subproblems" decomposition variable in pypsa_models.yml (see
+   resources/optim-config.yml) -- so this applies even though this writer is only
+   ever invoked for non-investment studies (see PyPSAStudyConverter._has_extendable_capacity).
    Without it, the solver refuses to load with "Scenario-independent variables are not
    supported in hybrid studies with sequential-subproblems resolution mode."
-5. Tag every component with `scenario-group: default` in `system.yml` and add
-   `input/data-series/modeler-scenariobuilder.dat` with an identity mapping
-   (MC year `i` -> data-series column `i + 1`). Without this, `antares-solver`'s hybrid
+5. Tag every component with scenario-group: default in system.yml and add
+   input/data-series/modeler-scenariobuilder.dat with an identity mapping
+   (MC year i -> data-series column i + 1). Without this, antares-solver's hybrid
    loader silently reuses the SAME data-series column for every MC year (unlike
    GemsPy's own Python loader, which defaults ungrouped components to an identity
    mapping automatically) -- so multi-scenario studies would silently solve every MC
@@ -58,89 +55,87 @@ This writer builds a "hybrid" study to get the best of both, validated end-to-en
 6. Run antares-solver -i <study_dir> (NOT antares-modeler), these studies are non-investment
 
 All of the above (steps 2-5 in particular) were reverse-engineered empirically against
-the actual `antares-solver` binary -- none of it is documented, hence the heavy
+the actual antares-solver binary -- none of it is documented, hence the heavy
 comments. If a newer Antares/GemsPy version changes this behaviour, this is the place
-to update (both this writer and `tests/e2e/test_hybrid_study_comparison.py`, which
+to update (both this writer and tests/e2e/test_hybrid_study_comparison.py, which
 validates it).
 """
 
 import math
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import antares.craft as antares_craft
 import yaml
 from pypsa import Network
 
 
+@dataclass
 class AntaresHybridStudyWriter:
-    """Writes the companion classic Antares study described in the module docstring,
-    as a sibling of the GEMS `systems/` folder produced by `GemsStudyWriter`."""
-
-    STUDY_NAME = "antares_hybrid_master"
-    STUDY_VERSION = "9.2"
-
-    def __init__(self, study_dir: Path):
-        self.study_dir = study_dir
+    study_dir: Path
+    study_name: str = "antares_hybrid_master"
+    study_version: str = "9.2"
 
     def write(self, gems_systems_dir: Path, pypsa_network: Network, n_scenarios: int) -> Path:
-        """Build the hybrid study and return its directory
-        (``self.study_dir / self.STUDY_NAME``)."""
+        """Build the hybrid study and return its directory (self.study_dir / self.study_name)."""
         antares_study_dir = self._build_virtual_antares_study(pypsa_network, n_scenarios)
         self._install_gems_system(antares_study_dir, gems_systems_dir, n_scenarios)
         return antares_study_dir
 
     def _build_virtual_antares_study(self, pypsa_network: Network, n_scenarios: int) -> Path:
-        """Steps 1 & 3 of the trick (see module docstring): a bare classic Antares
-        study with one inert area, and `nb_years` matching the GEMS scenario count."""
-        import antares.craft as ac
-
-        study_dir = self.study_dir / self.STUDY_NAME
+        """
+                                                       ^
+                                                       |
+                                                       |
+        Steps 1 & 3 of the trick (see module docstring |): a bare classic Antares
+        study with one inert area, and nb_years matching the GEMS scenario count.
+        """
+        study_dir = self.study_dir / self.study_name
         if study_dir.exists():
             shutil.rmtree(study_dir)
         self.study_dir.mkdir(parents=True, exist_ok=True)
 
-        study = ac.create_study_local(self.STUDY_NAME, self.STUDY_VERSION, str(self.study_dir))
+        study = antares_craft.create_study_local(self.study_name, self.study_version, str(self.study_dir))
         study.create_area(
             "virtual_area",
-            properties=ac.AreaProperties(
+            properties=antares_craft.AreaProperties(
                 energy_cost_unsupplied=0.0,
                 energy_cost_spilled=0.0,
                 non_dispatch_power=False,
                 dispatch_hydro_power=False,
                 other_dispatch_power=False,
             ),
-            # Deliberately no `create_link`, `create_thermal_cluster`, etc.: this area
+            # Deliberately no create_link, create_thermal_cluster, etc.: this area
             # is connected to nothing and contributes nothing to the objective.
         )
 
-        # antares-solver's `simplex-range = week` blocking is mandatory on this Antares
-        # version (`day` is a hard "deprecated" error), so the study horizon is
-        # expressed in whole weeks. GEMS timesteps are treated as hours throughout this
-        # converter (see e.g. write_antares_modeler_parameters_yml's use of
-        # len(snapshots) - 1 as an hour-indexed last-time-step), so we size the
-        # Antares calendar accordingly. A snapshot count that isn't an exact multiple
-        # of a week only triggers a harmless "partial week detected" trim/warning from
-        # antares-solver, not a failure.
         n_timesteps = len(pypsa_network.snapshots)
         simulation_end_days = max(1, math.ceil(n_timesteps / 24))
         study.update_settings(
-            ac.StudySettingsUpdate(
-                general_parameters=ac.GeneralParametersUpdate(
+            antares_craft.StudySettingsUpdate(
+                general_parameters=antares_craft.GeneralParametersUpdate(
                     simulation_start=1,
                     simulation_end=simulation_end_days,
                     nb_years=n_scenarios,
                 ),
-                optimization_parameters=ac.OptimizationParametersUpdate(
-                    simplex_range=ac.SimplexOptimizationRange.WEEK,
+                optimization_parameters=antares_craft.OptimizationParametersUpdate(
+                    simplex_range=antares_craft.SimplexOptimizationRange.WEEK,
                 ),
             )
         )
         return study_dir
 
     def _install_gems_system(self, antares_study_dir: Path, gems_systems_dir: Path, n_scenarios: int) -> None:
-        """Steps 2, 4 & 5 of the trick (see module docstring): graft the GEMS system
-        directly into the classic study's own `input/` directory."""
+        """
+                                                          ^
+                                                          |
+                                                          |
+                                                          |
+        Steps 2, 4 & 5 of the trick (see module docstring |): graft the GEMS system
+        directly into the classic study's own input/ directory.
+        """
         gems_input = gems_systems_dir / "input"
         antares_input = antares_study_dir / "input"
 

--- a/src/antares_hybrid_writer.py
+++ b/src/antares_hybrid_writer.py
@@ -69,18 +69,17 @@ from typing import Any
 
 import antares.craft as antares_craft
 import yaml
-from pypsa import Network
 
 
 @dataclass
 class AntaresHybridStudyWriter:
     study_dir: Path
-    study_name: str = "antares_hybrid_master"
-    study_version: str = "9.2"
+    study_name: str
+    study_version: str = "9.3"
 
-    def write(self, gems_systems_dir: Path, pypsa_network: Network, n_scenarios: int) -> Path:
+    def write(self, gems_systems_dir: Path, n_timesteps: int, n_scenarios: int) -> Path:
         """Build the hybrid study and return its directory (self.study_dir / self.study_name)."""
-        antares_study_dir = self._build_virtual_antares_study(pypsa_network, n_scenarios)
+        antares_study_dir = self._build_virtual_antares_study(n_timesteps, n_scenarios)
         self._add_gems_system(antares_study_dir, gems_systems_dir, n_scenarios)
         return antares_study_dir
 
@@ -110,8 +109,6 @@ class AntaresHybridStudyWriter:
             # Deliberately no create_link, create_thermal_cluster, etc.: this area
             # is connected to nothing and contributes nothing to the objective.
         )
-
-        n_timesteps = len(pypsa_network.snapshots)
         simulation_end_days = max(1, math.ceil(n_timesteps / 24))
         study.update_settings(
             antares_craft.StudySettingsUpdate(
@@ -127,7 +124,7 @@ class AntaresHybridStudyWriter:
         )
         return study_dir
 
-    def _install_gems_system(self, antares_study_dir: Path, gems_systems_dir: Path, n_scenarios: int) -> None:
+    def _add_gems_system(self, antares_study_dir: Path, gems_systems_dir: Path, n_scenarios: int) -> None:
         """
                                                           ^
                                                           |

--- a/src/antares_hybrid_writer.py
+++ b/src/antares_hybrid_writer.py
@@ -84,7 +84,7 @@ class AntaresHybridStudyWriter:
         self._add_gems_system(antares_study_dir, gems_systems_dir, n_scenarios)
         return antares_study_dir
 
-    def _build_virtual_antares_study(self, pypsa_network: Network, n_scenarios: int) -> Path:
+    def _build_virtual_antares_study(self, n_timesteps: int, n_scenarios: int) -> Path:
         """
                                                        ^
                                                        |

--- a/src/antares_hybrid_writer.py
+++ b/src/antares_hybrid_writer.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Builds a companion classic Antares study that makes a multi-scenario, non-investment
+GEMS study directly runnable end-to-end by the real antares-solver binary
+(antares-solver -i <path>), in addition to antares-modeler/GemsPy.
+
+Why this exists
+----------------
+antares-modeler invoked directly on a GEMS systems/ folder has no notion of
+Monte-Carlo years / generaldata.ini: it silently only ever solves scenario 0,
+regardless of how many scenarios the PyPSA/GEMS study actually declares.
+
+antares-solver (the real Antares engine) does understand Monte-Carlo years, but it
+only understands classic Antares studies (areas/links/thermal clusters) -- it has no
+notion of a GEMS system on its own. 
+This writer builds a "hybrid" study to get the best of both, validated end-to-end in tests/e2e/test_hybrid_study_comparison.py:
+
+1. Create a bare-bones classic Antares study with antares-craft, containing a single
+   "virtual_area" that is completely inert: zero unsupplied/spilled energy cost, no
+   load, no generation, no links, no thermal/renewable/storage clusters. It exists
+   purely so antares-solver has a classic area to load -- it is deliberately NOT
+   wired to the real system (no area_connections), so it cannot perturb the
+   objective value in any way.
+2. Copy the converted GEMS system (system.yml, model-libraries/, data-series/)
+   directly into the classic study's own input/ directory. antares-solver's hybrid
+   loader reads input/system.yml relative to the Antares study root -- confirmed
+   empirically by inspecting its own log output (System loaded, Data-series
+   loaded") and by grepping the binary for the literal string "system.yml".
+3. Set nb_years (Monte-Carlo years) in generaldata.ini, via antares-craft, to the
+   number of scenarios declared by the GEMS/PyPSA study, so Antares' own MC-year loop
+   lines up with the GEMS scenario axis.
+4. Add `resolution-mode: benders-decomposition` to `optim-config.yml`. This is required
+   by `antares-solver`'s hybrid loader for ANY model with an investment-style variable --
+   even non-extendable (`p_nom_extendable=False`) generators declare `p_nom` as a
+   "master-and-subproblems" decomposition variable in `pypsa_models.yml` (see
+   `resources/optim-config.yml`) -- so this applies even though this writer is only
+   ever invoked for non-investment studies (see `PyPSAStudyConverter._has_extendable_capacity`).
+   Without it, the solver refuses to load with "Scenario-independent variables are not
+   supported in hybrid studies with sequential-subproblems resolution mode."
+5. Tag every component with `scenario-group: default` in `system.yml` and add
+   `input/data-series/modeler-scenariobuilder.dat` with an identity mapping
+   (MC year `i` -> data-series column `i + 1`). Without this, `antares-solver`'s hybrid
+   loader silently reuses the SAME data-series column for every MC year (unlike
+   GemsPy's own Python loader, which defaults ungrouped components to an identity
+   mapping automatically) -- so multi-scenario studies would silently solve every MC
+   year against scenario 0 only.
+6. Run antares-solver -i <study_dir> (NOT antares-modeler), these studies are non-investment
+
+All of the above (steps 2-5 in particular) were reverse-engineered empirically against
+the actual `antares-solver` binary -- none of it is documented, hence the heavy
+comments. If a newer Antares/GemsPy version changes this behaviour, this is the place
+to update (both this writer and `tests/e2e/test_hybrid_study_comparison.py`, which
+validates it).
+"""
+
+import math
+import shutil
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pypsa import Network
+
+
+class AntaresHybridStudyWriter:
+    """Writes the companion classic Antares study described in the module docstring,
+    as a sibling of the GEMS `systems/` folder produced by `GemsStudyWriter`."""
+
+    STUDY_NAME = "antares_hybrid_master"
+    STUDY_VERSION = "9.2"
+
+    def __init__(self, study_dir: Path):
+        self.study_dir = study_dir
+
+    def write(self, gems_systems_dir: Path, pypsa_network: Network, n_scenarios: int) -> Path:
+        """Build the hybrid study and return its directory
+        (``self.study_dir / self.STUDY_NAME``)."""
+        antares_study_dir = self._build_virtual_antares_study(pypsa_network, n_scenarios)
+        self._install_gems_system(antares_study_dir, gems_systems_dir, n_scenarios)
+        return antares_study_dir
+
+    def _build_virtual_antares_study(self, pypsa_network: Network, n_scenarios: int) -> Path:
+        """Steps 1 & 3 of the trick (see module docstring): a bare classic Antares
+        study with one inert area, and `nb_years` matching the GEMS scenario count."""
+        import antares.craft as ac
+
+        study_dir = self.study_dir / self.STUDY_NAME
+        if study_dir.exists():
+            shutil.rmtree(study_dir)
+        self.study_dir.mkdir(parents=True, exist_ok=True)
+
+        study = ac.create_study_local(self.STUDY_NAME, self.STUDY_VERSION, str(self.study_dir))
+        study.create_area(
+            "virtual_area",
+            properties=ac.AreaProperties(
+                energy_cost_unsupplied=0.0,
+                energy_cost_spilled=0.0,
+                non_dispatch_power=False,
+                dispatch_hydro_power=False,
+                other_dispatch_power=False,
+            ),
+            # Deliberately no `create_link`, `create_thermal_cluster`, etc.: this area
+            # is connected to nothing and contributes nothing to the objective.
+        )
+
+        # antares-solver's `simplex-range = week` blocking is mandatory on this Antares
+        # version (`day` is a hard "deprecated" error), so the study horizon is
+        # expressed in whole weeks. GEMS timesteps are treated as hours throughout this
+        # converter (see e.g. write_antares_modeler_parameters_yml's use of
+        # len(snapshots) - 1 as an hour-indexed last-time-step), so we size the
+        # Antares calendar accordingly. A snapshot count that isn't an exact multiple
+        # of a week only triggers a harmless "partial week detected" trim/warning from
+        # antares-solver, not a failure.
+        n_timesteps = len(pypsa_network.snapshots)
+        simulation_end_days = max(1, math.ceil(n_timesteps / 24))
+        study.update_settings(
+            ac.StudySettingsUpdate(
+                general_parameters=ac.GeneralParametersUpdate(
+                    simulation_start=1,
+                    simulation_end=simulation_end_days,
+                    nb_years=n_scenarios,
+                ),
+                optimization_parameters=ac.OptimizationParametersUpdate(
+                    simplex_range=ac.SimplexOptimizationRange.WEEK,
+                ),
+            )
+        )
+        return study_dir
+
+    def _install_gems_system(self, antares_study_dir: Path, gems_systems_dir: Path, n_scenarios: int) -> None:
+        """Steps 2, 4 & 5 of the trick (see module docstring): graft the GEMS system
+        directly into the classic study's own `input/` directory."""
+        gems_input = gems_systems_dir / "input"
+        antares_input = antares_study_dir / "input"
+
+        shutil.copy(gems_input / "system.yml", antares_input / "system.yml")
+        shutil.copytree(gems_input / "model-libraries", antares_input / "model-libraries", dirs_exist_ok=True)
+        shutil.copytree(gems_input / "data-series", antares_input / "data-series", dirs_exist_ok=True)
+
+        # `resolution-mode: benders-decomposition` is required by antares-solver's
+        # hybrid loader (see module docstring, step 4) -- this deliberately overrides
+        # whatever optim-config.yml GemsStudyWriter itself wrote for the GEMS-only
+        # (antares-modeler/GemsPy) path, reusing the same per-model decomposition
+        # config for the hybrid, antares-solver-driven path.
+        optim_config_src = Path(__file__).parent.parent / "resources" / "optim-config.yml"
+        (antares_input / "optim-config.yml").write_text(
+            "resolution-mode: benders-decomposition\n" + optim_config_src.read_text()
+        )
+
+        # Tag every component with the same scenario-group and add an identity
+        # modeler-scenariobuilder.dat (MC year i -> data-series column i+1), so
+        # antares-solver picks a distinct data-series column per MC year instead of
+        # silently reusing column 1 for every year (see module docstring, step 5).
+        system_yml_path = antares_input / "system.yml"
+        with system_yml_path.open() as f:
+            system_data: dict[str, Any] = yaml.safe_load(f)
+        for component in system_data["system"].get("components", []):
+            component["scenario-group"] = "default"
+        with system_yml_path.open("w") as f:
+            yaml.dump(
+                {"system": system_data["system"]}, f, default_flow_style=False, sort_keys=False, allow_unicode=True
+            )
+
+        scenariobuilder_lines = [f"default, {i} = {i + 1}" for i in range(n_scenarios)]
+        (antares_input / "data-series" / "modeler-scenariobuilder.dat").write_text(
+            "\n".join(scenariobuilder_lines) + "\n"
+        )

--- a/src/antares_hybrid_writer.py
+++ b/src/antares_hybrid_writer.py
@@ -23,7 +23,7 @@ regardless of how many scenarios the PyPSA/GEMS study actually declares.
 
 antares-solver (the real Antares engine) does understand Monte-Carlo years, but it
 only understands classic Antares studies (areas/links/thermal clusters) -- it has no
-notion of a GEMS system on its own. 
+notion of a GEMS system on its own.
 This writer builds a "hybrid" study to get the best of both, validated end-to-end in tests/e2e/test_hybrid_study_comparison.py:
 
 1. Create a bare-bones classic Antares study with antares-craft, containing a single

--- a/src/antares_hybrid_writer.py
+++ b/src/antares_hybrid_writer.py
@@ -140,15 +140,12 @@ class AntaresHybridStudyWriter:
         shutil.copytree(gems_input / "model-libraries", antares_input / "model-libraries", dirs_exist_ok=True)
         shutil.copytree(gems_input / "data-series", antares_input / "data-series", dirs_exist_ok=True)
 
-        # `resolution-mode: benders-decomposition` is required by antares-solver's
-        # hybrid loader (see module docstring, step 4) -- this deliberately overrides
-        # whatever optim-config.yml GemsStudyWriter itself wrote for the GEMS-only
-        # (antares-modeler/GemsPy) path, reusing the same per-model decomposition
-        # config for the hybrid, antares-solver-driven path.
+        # Step 4: hybrid loader requires benders-decomposition for any study whose
+        # models declare master/subproblem variables (including fixed p_nom). Without
+        # this file, antares-solver refuses to load the hybrid study.
+        # resources/optim-config.yml already sets resolution-mode: benders-decomposition.
         optim_config_src = Path(__file__).parent.parent / "resources" / "optim-config.yml"
-        (antares_input / "optim-config.yml").write_text(
-            "resolution-mode: benders-decomposition\n" + optim_config_src.read_text()
-        )
+        shutil.copy(optim_config_src, antares_input / "optim-config.yml")
 
         # Tag every component with the same scenario-group and add an identity
         # modeler-scenariobuilder.dat (MC year i -> data-series column i+1), so

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -65,6 +65,11 @@ def get_antares_modeler_bin(base_dir: Path) -> Path:
     return base_dir / get_antares_dir_name() / "bin" / "antares-modeler"
 
 
+def get_antares_solver_bin(base_dir: Path) -> Path:
+    """Return path to antares-solver binary under base_dir."""
+    return base_dir / get_antares_dir_name() / "bin" / "antares-solver"
+
+
 def get_antares_xpansion_benders_bin(base_dir: Path) -> Path:
     """Return path to benders binary under base_dir (Antares Xpansion)."""
     return base_dir / get_antares_xpansion_dir_name() / "bin" / "benders"

--- a/src/models/gems_system_yml_schema/gems_system.py
+++ b/src/models/gems_system_yml_schema/gems_system.py
@@ -57,7 +57,7 @@ class GemsSystem(ModifiedBaseModel):
 
     def to_dict(self, by_alias: bool = True, exclude_unset: bool = True) -> dict[str, Any]:
         """Convert GemsSystem object to dictionary, handling PrivateAttr fields and nested Pydantic models."""
-        return {
+        data: dict[str, Any] = {
             "id": self._id,
             "model_libraries": self._model_libraries,
             "components": [
@@ -70,10 +70,16 @@ class GemsSystem(ModifiedBaseModel):
             ]
             if self._connections
             else None,
-            "area_connections": [
-                area_conn.model_dump(by_alias=by_alias, exclude_unset=exclude_unset)
-                for area_conn in (self._area_connections or [])
-            ]
-            if self._area_connections
-            else None,
         }
+        # area_connections is a hybrid-study-only field (see gems_craft_hybrid.study.parsing
+        # / HybridSystemSchema).
+        # The plain (non-hybrid) SystemSchema used by gemspy>=0.1.3
+        # forbids unknown/extra keys, so it must be omitted entirely here rather than written
+        # as area_connections: null -- only the antares-solver hybrid-study trick (see
+        # tests/e2e/test_hybrid_study_comparison.py) actually populates this field.
+        if self._area_connections:
+            data["area_connections"] = [
+                area_conn.model_dump(by_alias=by_alias, exclude_unset=exclude_unset)
+                for area_conn in self._area_connections
+            ]
+        return data

--- a/src/pypsa_converter.py
+++ b/src/pypsa_converter.py
@@ -32,11 +32,7 @@ _EXTENDABLE_CAPACITY_COMPONENTS: dict[str, str] = {
     "links": "p_nom_extendable",
     "storage_units": "p_nom_extendable",
     "stores": "e_nom_extendable",
-    # For consideration: do we want to support this too? Lines/transformers have their
-    # own extendable-capacity attribute (s_nom_extendable). Left out for now, so a
-    # study with only extendable lines/transformers (no extendable generator/link/
-    # storage_unit/store) is currently misclassified as non-investment here and would
-    # get the antares-solver hybrid trick applied (see _has_extendable_capacity below).
+    # For consideration, currently not processed
     # "lines": "s_nom_extendable",
     # "transformers": "s_nom_extendable",
 }
@@ -77,18 +73,7 @@ class PyPSAStudyConverter:
     def _validate_scenario_weightings(self) -> None:
         """
         Multi-scenario studies currently require every scenario to carry the SAME weight.
-
-        GemsPy's own ``expec()`` operator (used to combine each scenario's operational
-        objective contribution) currently computes a plain, unweighted arithmetic mean
-        across scenarios -- it does not consume PyPSA's scenario_weightings at all. With
-        equal weights the unweighted and true weighted average coincide, so results are
-        correct; with unequal weights they silently diverge (see
-        tests/e2e/test_hybrid_study_comparison.py::
-        test_hybrid_two_scenarios_unequal_weights_matches_pypsa for a worked example: pypsa's
-        true weighted objective differs from GemsPy's for 0.1/0.9 weights, but not for
-        0.5/0.5). Rather than silently producing a GEMS study whose GemsPy/antares-modeler
-        results don't match PyPSA's, we fail fast at conversion time until GemsPy's
-        ``expec()`` supports per-scenario weights.
+        Because of GEMSPy behavior, 1/N where N is the number of scenarios.
         """
         weights = list(self.scenario_weightings.values())
         if len(weights) <= 1:
@@ -162,14 +147,16 @@ class PyPSAStudyConverter:
         system_id = self.system_name if self.system_name not in {"", None} else "pypsa_to_gems_converter"
         gems_study_writer.write_gems_system_yml(list_components, list_connections, system_id, self.pypsalib_id)
         gems_study_writer.write_antares_modeler_parameters_yml(len(self.pypsa_network.snapshots) - 1, self.solver_name)
+
         # One scenario -> deterministic study, nothing more to write.
+        # Runnable by antares modeler directly
         if len(self.scenario_weightings.keys()) > 1:
             if self._has_extendable_capacity():
                 # Investment study: optim-config.yml's model-decomposition is what lets
                 # antares-modeler/GemsPy run the master/subproblem Benders split.
                 gems_study_writer.write_optim_config_yml()
             else:
-                # Multi-scenario, non-investment study: antares-modeler invoked directly has
+                # Multi-scenario, operational study: antares-modeler invoked directly has
                 # no notion of Monte-Carlo years, so it silently only ever solves scenario 0.
                 # To get a study that is directly runnable end-to-end with the real Antares
                 # engine and produces the correct scenario-weighted result, we additionally

--- a/src/pypsa_converter.py
+++ b/src/pypsa_converter.py
@@ -27,7 +27,7 @@ CONVERTER_LOGGER_NAME = "pypsa_to_gems_converter"
 _CONVERTER_LOG = logging.getLogger(CONVERTER_LOGGER_NAME)
 
 # Components carrying an extendable capacity variable, keyed by their "*_extendable" column.
-_EXTENDABLE_CAPACITY_COMPONENTS: dict[str, str] = {
+_EXTENDABLE_CAPACITY_FLAGS: dict[str, str] = {
     "generators": "p_nom_extendable",
     "links": "p_nom_extendable",
     "storage_units": "p_nom_extendable",

--- a/src/pypsa_converter.py
+++ b/src/pypsa_converter.py
@@ -100,7 +100,7 @@ class PyPSAStudyConverter:
         (see PyPSAPreprocessor._fix_capacity_non_extendable_attribute), so they never introduce a
         master variable.
         """
-        for component_type, extendable_col in _EXTENDABLE_CAPACITY_COMPONENTS.items():
+        for component_type, extendable_col in _EXTENDABLE_CAPACITY_FLAGS.items():
             df = getattr(self.pypsa_network, component_type)
             if len(df) > 0 and bool(df[extendable_col].any()):
                 return True
@@ -164,9 +164,9 @@ class PyPSAStudyConverter:
                 # tests/e2e/test_hybrid_study_comparison.py: running
                 # `antares-solver -i <path printed below>` solves every declared scenario
                 # and combines them per generaldata.ini's nb_years / scenario weights.
-                antares_hybrid_dir = AntaresHybridStudyWriter(self.study_dir).write(
+                antares_hybrid_dir = AntaresHybridStudyWriter(self.study_dir, study_name=self.pypsa_network.name).write(
                     gems_systems_dir=self.study_dir / "systems",
-                    pypsa_network=self.pypsa_network,
+                    n_timesteps=len(self.pypsa_network.snapshots),
                     n_scenarios=len(self.scenario_weightings),
                 )
                 self.logger.info(

--- a/src/pypsa_converter.py
+++ b/src/pypsa_converter.py
@@ -11,10 +11,12 @@
 # This file is part of the Antares project.
 import copy
 import logging
+import math
 from pathlib import Path
 
 from pypsa import Network
 
+from src.antares_hybrid_writer import AntaresHybridStudyWriter
 from src.gems_model_builder import GemsModelBuilder
 from src.gems_study_writer import GemsStudyWriter
 from src.pypsa_preprocessor import PyPSAPreprocessor
@@ -23,6 +25,21 @@ from src.utils import check_time_series_format, determine_pypsa_study_type
 
 CONVERTER_LOGGER_NAME = "pypsa_to_gems_converter"
 _CONVERTER_LOG = logging.getLogger(CONVERTER_LOGGER_NAME)
+
+# Components carrying an extendable capacity variable, keyed by their "*_extendable" column.
+_EXTENDABLE_CAPACITY_COMPONENTS: dict[str, str] = {
+    "generators": "p_nom_extendable",
+    "links": "p_nom_extendable",
+    "storage_units": "p_nom_extendable",
+    "stores": "e_nom_extendable",
+    # For consideration: do we want to support this too? Lines/transformers have their
+    # own extendable-capacity attribute (s_nom_extendable). Left out for now, so a
+    # study with only extendable lines/transformers (no extendable generator/link/
+    # storage_unit/store) is currently misclassified as non-investment here and would
+    # get the antares-solver hybrid trick applied (see _has_extendable_capacity below).
+    # "lines": "s_nom_extendable",
+    # "transformers": "s_nom_extendable",
+}
 
 
 class PyPSAStudyConverter:
@@ -49,12 +66,60 @@ class PyPSAStudyConverter:
         self.system_name = pypsa_network.name
         self.series_file_format = check_time_series_format(series_file_format)
         self.pypsa_network, self.scenario_weightings = determine_pypsa_study_type(self.pypsa_network)
+        self._validate_scenario_weightings()
         self.solver_name = solver_name
 
         # Preprocess the network
         self.pypsa_network = PyPSAPreprocessor(self.pypsa_network).network_preprocessing()
         # Register the PyPSA components and global constraints
         self.pypsa_components_data, self.pypsa_globalconstraints_data = PyPSARegister(self.pypsa_network).register()
+
+    def _validate_scenario_weightings(self) -> None:
+        """
+        Multi-scenario studies currently require every scenario to carry the SAME weight.
+
+        GemsPy's own ``expec()`` operator (used to combine each scenario's operational
+        objective contribution) currently computes a plain, unweighted arithmetic mean
+        across scenarios -- it does not consume PyPSA's scenario_weightings at all. With
+        equal weights the unweighted and true weighted average coincide, so results are
+        correct; with unequal weights they silently diverge (see
+        tests/e2e/test_hybrid_study_comparison.py::
+        test_hybrid_two_scenarios_unequal_weights_matches_pypsa for a worked example: pypsa's
+        true weighted objective differs from GemsPy's for 0.1/0.9 weights, but not for
+        0.5/0.5). Rather than silently producing a GEMS study whose GemsPy/antares-modeler
+        results don't match PyPSA's, we fail fast at conversion time until GemsPy's
+        ``expec()`` supports per-scenario weights.
+        """
+        weights = list(self.scenario_weightings.values())
+        if len(weights) <= 1:
+            return
+        reference = weights[0]
+        if not all(math.isclose(w, reference, rel_tol=1e-9, abs_tol=1e-12) for w in weights):
+            raise ValueError(
+                "Multi-scenario studies currently require every scenario to have the same "
+                f"weight, but got unequal weights: {self.scenario_weightings!r}. GemsPy's "
+                "expec() operator computes an unweighted average across scenarios, so "
+                "unequal weights would silently produce GemsPy/antares-modeler results that "
+                "don't match PyPSA's true (probability-weighted) objective. Use equal "
+                "weights for every scenario until GemsPy's expec() supports per-scenario "
+                "weights."
+            )
+
+    def _has_extendable_capacity(self) -> bool:
+        """
+        Whether the network has at least one component with a free (extendable) capacity variable.
+
+        This is what actually makes a study an investment problem, independently of scenario count:
+        p_nom/e_nom is a decision variable only when *_extendable=True. Non-extendable components
+        have their bounds fixed to the same value by the preprocessor
+        (see PyPSAPreprocessor._fix_capacity_non_extendable_attribute), so they never introduce a
+        master variable.
+        """
+        for component_type, extendable_col in _EXTENDABLE_CAPACITY_COMPONENTS.items():
+            df = getattr(self.pypsa_network, component_type)
+            if len(df) > 0 and bool(df[extendable_col].any()):
+                return True
+        return False
 
     def to_gems_study(self) -> None:
         """Main function, to export PyPSA as Gems study"""
@@ -97,8 +162,29 @@ class PyPSAStudyConverter:
         system_id = self.system_name if self.system_name not in {"", None} else "pypsa_to_gems_converter"
         gems_study_writer.write_gems_system_yml(list_components, list_connections, system_id, self.pypsalib_id)
         gems_study_writer.write_antares_modeler_parameters_yml(len(self.pypsa_network.snapshots) - 1, self.solver_name)
-        # Write optim_config.yml if there are scenarios
-        # One scenario -> deterministic study
+        # One scenario -> deterministic study, nothing more to write.
         if len(self.scenario_weightings.keys()) > 1:
-            gems_study_writer.write_optim_config_yml()
+            if self._has_extendable_capacity():
+                # Investment study: optim-config.yml's model-decomposition is what lets
+                # antares-modeler/GemsPy run the master/subproblem Benders split.
+                gems_study_writer.write_optim_config_yml()
+            else:
+                # Multi-scenario, non-investment study: antares-modeler invoked directly has
+                # no notion of Monte-Carlo years, so it silently only ever solves scenario 0.
+                # To get a study that is directly runnable end-to-end with the real Antares
+                # engine and produces the correct scenario-weighted result, we additionally
+                # emit a companion classic Antares study wired via the trick validated in
+                # tests/e2e/test_hybrid_study_comparison.py: running
+                # `antares-solver -i <path printed below>` solves every declared scenario
+                # and combines them per generaldata.ini's nb_years / scenario weights.
+                antares_hybrid_dir = AntaresHybridStudyWriter(self.study_dir).write(
+                    gems_systems_dir=self.study_dir / "systems",
+                    pypsa_network=self.pypsa_network,
+                    n_scenarios=len(self.scenario_weightings),
+                )
+                self.logger.info(
+                    "Antares-runnable hybrid study written to %s (run: antares-solver -i %s)",
+                    antares_hybrid_dir,
+                    antares_hybrid_dir,
+                )
         self.logger.info("Study conversion completed!")

--- a/src/pypsa_converter.py
+++ b/src/pypsa_converter.py
@@ -106,6 +106,48 @@ class PyPSAStudyConverter:
                 return True
         return False
 
+    def _write_multi_scenario_outputs(self, gems_study_writer: GemsStudyWriter) -> None:
+        """
+        Extra outputs required when the study has more than one scenario.
+
+        - Investment (extendable capacity): write optim-config.yml for Benders / modeler.
+        - Operational (no extendable capacity): write a companion Antares hybrid study so
+          antares-solver can run every Monte-Carlo year. Only when the horizon is a
+          multiple of 168 hours (full weeks); otherwise skip the hybrid study (GEMS
+          systems/ is still written). Antares Economy truncates incomplete weeks
+          (see Antares StudyRuntimeInfos::initializeRangeLimits).
+        """
+        if len(self.scenario_weightings) <= 1:
+            return
+
+        if self._has_extendable_capacity():
+            # Investment study: optim-config.yml's model-decomposition is what lets
+            # antares-xpansion/GemsPy run the master/subproblem Benders split.
+            gems_study_writer.write_optim_config_yml()
+            return
+
+        n_timesteps = len(self.pypsa_network.snapshots)
+        if n_timesteps % 168 != 0:
+            raise ValueError(
+                "Horizon has %s timesteps, not a multiple of 168 (full weeks). Antares Economy would drop the incomplete trailing week.",
+                n_timesteps,
+            )
+
+        # Multi-scenario operational study: antares-modeler invoked directly has no notion
+        # of Monte-Carlo years, so it silently only ever solves scenario 0. Emit a companion
+        # classic Antares study (trick validated in tests/e2e/test_hybrid_study_comparison.py)
+        # so `antares-solver -i <path>` solves every declared scenario.
+        antares_hybrid_dir = AntaresHybridStudyWriter(self.study_dir, study_name=self.pypsa_network.name).write(
+            gems_systems_dir=self.study_dir / "systems",
+            n_timesteps=n_timesteps,
+            n_scenarios=len(self.scenario_weightings),
+        )
+        self.logger.info(
+            "Antares-runnable hybrid study written to %s (run: antares-solver -i %s)",
+            antares_hybrid_dir,
+            antares_hybrid_dir,
+        )
+
     def to_gems_study(self) -> None:
         """Main function, to export PyPSA as Gems study"""
 
@@ -148,30 +190,6 @@ class PyPSAStudyConverter:
         gems_study_writer.write_gems_system_yml(list_components, list_connections, system_id, self.pypsalib_id)
         gems_study_writer.write_antares_modeler_parameters_yml(len(self.pypsa_network.snapshots) - 1, self.solver_name)
 
-        # One scenario -> deterministic study, nothing more to write.
-        # Runnable by antares modeler directly
-        if len(self.scenario_weightings.keys()) > 1:
-            if self._has_extendable_capacity():
-                # Investment study: optim-config.yml's model-decomposition is what lets
-                # antares-modeler/GemsPy run the master/subproblem Benders split.
-                gems_study_writer.write_optim_config_yml()
-            else:
-                # Multi-scenario, operational study: antares-modeler invoked directly has
-                # no notion of Monte-Carlo years, so it silently only ever solves scenario 0.
-                # To get a study that is directly runnable end-to-end with the real Antares
-                # engine and produces the correct scenario-weighted result, we additionally
-                # emit a companion classic Antares study wired via the trick validated in
-                # tests/e2e/test_hybrid_study_comparison.py: running
-                # `antares-solver -i <path printed below>` solves every declared scenario
-                # and combines them per generaldata.ini's nb_years / scenario weights.
-                antares_hybrid_dir = AntaresHybridStudyWriter(self.study_dir, study_name=self.pypsa_network.name).write(
-                    gems_systems_dir=self.study_dir / "systems",
-                    n_timesteps=len(self.pypsa_network.snapshots),
-                    n_scenarios=len(self.scenario_weightings),
-                )
-                self.logger.info(
-                    "Antares-runnable hybrid study written to %s (run: antares-solver -i %s)",
-                    antares_hybrid_dir,
-                    antares_hybrid_dir,
-                )
+        # One scenario -> deterministic study, runnable by antares-modeler directly.
+        self._write_multi_scenario_outputs(gems_study_writer)
         self.logger.info("Study conversion completed!")

--- a/tests/e2e/test_hybrid_study_comparison.py
+++ b/tests/e2e/test_hybrid_study_comparison.py
@@ -40,9 +40,8 @@ from gems_runner.simulation.time_block import TimeBlock
 from pypsa import Network
 
 from src.antares_hybrid_writer import AntaresHybridStudyWriter
-from src.dependencies import get_antares_dir_name, get_antares_modeler_bin, get_antares_solver_bin
+from src.dependencies import get_antares_dir_name, get_antares_solver_bin
 from src.pypsa_converter import PyPSAStudyConverter
-from tests.utils import get_objective_value
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -60,9 +59,11 @@ def check_hybrid_prerequisites() -> None:
 
 
 def _run_hybrid_solver(antares_study_dir: Path) -> Path:
-    """Step 6 of the trick (see src/antares_hybrid_writer.py's module docstring): run
+    """
+    Step 6 of the trick (see src/antares_hybrid_writer.py's module docstring): run
     antares-solver with no mode flag (generaldata.ini defaults to Economy; there is
-    nothing to expand) and return the resulting simulation_table CSV."""
+    nothing to expand) and return the resulting simulation_table CSV.
+    """
     solver_bin = get_antares_solver_bin(PROJECT_ROOT)
     if antares_study_dir.joinpath("output").exists():
         shutil.rmtree(antares_study_dir / "output")
@@ -85,10 +86,12 @@ def _run_hybrid_solver(antares_study_dir: Path) -> Path:
 
 
 def _weighted_objective(simulation_table: Path, scenario_weights: list[float]) -> float:
-    """`tests.utils.get_objective_value` only reads the *first* OBJECTIVE_VALUE row,
+    """
+    tests.utils.get_objective_value only reads the *first* OBJECTIVE_VALUE row,
     which is fine for single-scenario runs but not for multi-scenario ones: antares-solver
     writes one OBJECTIVE_VALUE row per MC year/scenario_index, and they must be
-    combined the same way PyPSA/GemsPy combine them (weighted average)."""
+    combined the same way PyPSA/GemsPy combine them (weighted average).
+    """
     df = pd.read_csv(simulation_table, usecols=["output", "scenario_index", "value"])
     per_scenario = df.query("output == 'OBJECTIVE_VALUE'").set_index("scenario_index")["value"]
     return float(sum(per_scenario[i] * scenario_weights[i] for i in range(len(scenario_weights))))
@@ -110,67 +113,9 @@ def _gemspy_objective(gems_systems_dir: Path, n_scenarios: int) -> float:
     return float(problem.objective_value)
 
 
-def _antares_modeler_objective(gems_systems_dir: Path) -> float:
-    """Direct antares-modeler invocation, same pattern as end_2_end_tests.py's
-    get_gems_study_objective(). Note: this only ever solves ONE scenario -- see
-    module docstring -- so it is only compared for the deterministic fixture."""
-    antares_modeler_bin = get_antares_modeler_bin(PROJECT_ROOT)
-    if (gems_systems_dir / "output").exists():
-        shutil.rmtree(gems_systems_dir / "output")
-
-    subprocess.run(
-        [str(antares_modeler_bin), str(gems_systems_dir)],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=str(antares_modeler_bin.parent),
-    )
-    result_file = next(gems_systems_dir.glob("output/**/simulation_table*"), None)
-    if result_file is None:
-        raise FileNotFoundError(f"No simulation_table found under {gems_systems_dir / 'output'}")
-    return get_objective_value(result_file)
-
-
-def test_hybrid_deterministic_matches_all_execution_paths() -> None:
-    """Single-scenario network: pypsa / antares-modeler / gemspy / antares-solver
-    (hybrid trick) must all agree exactly.
-
-    The converter itself only auto-builds the hybrid study for genuine multi-scenario
-    studies (see `PyPSAStudyConverter.to_gems_study`), so this baseline calls
-    `AntaresHybridStudyWriter` directly to confirm the trick introduces no bias before
-    checking real multi-scenario behaviour below.
-    """
-    study_name = "test_hybrid_deterministic"
-    gems_dir = PROJECT_ROOT / "tmp" / study_name
-
-    network = Network(name="HybridDeterministic", snapshots=list(range(HOURS_PER_WEEK)))
-    network.add("Bus", "town", v_nom=1)
-    network.add("Load", "load1", bus="town", p_set=[80 + (i % 24) for i in range(HOURS_PER_WEEK)], q_set=0)
-    network.add("Generator", "gen1", bus="town", p_nom_extendable=False, marginal_cost=50, p_nom=200)
-    network.add("Generator", "gen2", bus="town", p_nom_extendable=False, marginal_cost=10, p_nom=50)
-
-    PyPSAStudyConverter(pypsa_network=network, study_dir=gems_dir, series_file_format=".tsv").to_gems_study()
-    gems_systems_dir = gems_dir / "systems"
-
-    network.optimize()
-    pypsa_objective = network.objective + network.objective_constant
-
-    modeler_objective = _antares_modeler_objective(gems_systems_dir)
-    gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=1)
-
-    antares_study_dir = AntaresHybridStudyWriter(gems_dir).write(
-        gems_systems_dir=gems_systems_dir, pypsa_network=network, n_scenarios=1
-    )
-    hybrid_result_file = _run_hybrid_solver(antares_study_dir)
-    hybrid_objective = _weighted_objective(hybrid_result_file, scenario_weights=[1.0])
-
-    assert math.isclose(pypsa_objective, modeler_objective, rel_tol=1e-6)
-    assert math.isclose(pypsa_objective, gemspy_objective, rel_tol=1e-6)
-    assert math.isclose(pypsa_objective, hybrid_objective, rel_tol=1e-6)
-
-
 def test_hybrid_two_scenarios_matches_pypsa_and_gemspy() -> None:
-    """Two-scenario (stochastic) network: pypsa / gemspy / antares-solver (hybrid
+    """
+    Two-scenario (stochastic) network: pypsa / gemspy / antares-solver (hybrid
     trick) must agree on the scenario-weighted objective.
 
     Unlike the deterministic baseline above, this study IS multi-scenario and
@@ -217,7 +162,7 @@ def test_hybrid_two_scenarios_matches_pypsa_and_gemspy() -> None:
 
     gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=2)
 
-    antares_study_dir = gems_dir / AntaresHybridStudyWriter.STUDY_NAME
+    antares_study_dir = gems_dir / AntaresHybridStudyWriter.study_name
     assert antares_study_dir.is_dir(), (
         "to_gems_study() should have auto-built the antares-solver hybrid study "
         "for this multi-scenario, non-investment network by default"
@@ -230,22 +175,12 @@ def test_hybrid_two_scenarios_matches_pypsa_and_gemspy() -> None:
 
 
 def test_unequal_scenario_weights_are_rejected() -> None:
-    """Multi-scenario studies with UNEQUAL scenario weights (0.1 / 0.9) must be
+    """
+    Multi-scenario studies with UNEQUAL scenario weights (0.1 / 0.9) must be
     rejected at conversion time with a clear error, rather than silently producing a
     GEMS study whose GemsPy/antares-modeler results don't match PyPSA's.
-
-    This is a real gap, not a hypothetical one: GemsPy's `expec()` operator (see the
-    "Expectation semantics (average over scenarios) are applied automatically"
-    UserWarning emitted during model resolution) currently computes a plain,
-    UNWEIGHTED arithmetic mean across scenarios -- it does not consume PyPSA's
-    scenario_weightings at all. With equal weights (0.5/0.5, see
-    `test_hybrid_two_scenarios_matches_pypsa_and_gemspy` above) the unweighted and
-    true weighted average coincide, so results are correct; with unequal weights
-    (e.g. 0.1/0.9 here) they silently diverge:
-      - pypsa's true weighted objective:  0.1 * 432600 + 0.9 * 701400 = 674520.0
-      - gemspy's unweighted average:       (432600 + 701400) / 2      = 567000.0
-    `PyPSAStudyConverter._validate_scenario_weightings` fails fast on construction
-    instead, until GemsPy's `expec()` supports per-scenario weights.
+    - pypsa's true weighted objective:  0.1 * 432600 + 0.9 * 701400 = 674520.0
+    - gemspy's unweighted average:       (432600 + 701400) / 2      = 567000.0
     """
     study_name = "test_unequal_scenario_weights"
     gems_dir = PROJECT_ROOT / "tmp" / study_name

--- a/tests/e2e/test_hybrid_study_comparison.py
+++ b/tests/e2e/test_hybrid_study_comparison.py
@@ -49,14 +49,6 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 HOURS_PER_WEEK = 168
 
 
-def _antares_craft_available() -> bool:
-    try:
-        import antares.craft  # noqa: F401
-    except ImportError:
-        return False
-    return True
-
-
 @pytest.fixture(autouse=True)
 def check_hybrid_prerequisites() -> None:
     """Skip (rather than fail) when the Antares binaries or antares-craft aren't available."""
@@ -65,8 +57,6 @@ def check_hybrid_prerequisites() -> None:
             f"Antares binaries not found. Please download version from "
             f"https://github.com/AntaresSimulatorTeam/Antares_Simulator/releases into {PROJECT_ROOT}"
         )
-    if not _antares_craft_available():
-        pytest.skip("antares-craft is not installed (needed to build the hybrid-study trick).")
 
 
 def _run_hybrid_solver(antares_study_dir: Path) -> Path:
@@ -77,18 +67,13 @@ def _run_hybrid_solver(antares_study_dir: Path) -> Path:
     if antares_study_dir.joinpath("output").exists():
         shutil.rmtree(antares_study_dir / "output")
 
-    result = subprocess.run(
+    subprocess.run(
         [str(solver_bin), "-i", str(antares_study_dir)],
         capture_output=True,
         text=True,
         check=False,
         cwd=str(solver_bin.parent),
     )
-    print("================================")
-    print("Antares solver (hybrid) output: returncode=%s" % result.returncode)
-    print("stdout:", result.stdout)
-    print("stderr:", result.stderr)
-    print("================================")
 
     result_file = next(antares_study_dir.glob("output/**/simulation_table*"), None)
     if result_file is None:
@@ -179,11 +164,6 @@ def test_hybrid_deterministic_matches_all_execution_paths() -> None:
     hybrid_result_file = _run_hybrid_solver(antares_study_dir)
     hybrid_objective = _weighted_objective(hybrid_result_file, scenario_weights=[1.0])
 
-    print(
-        f"pypsa={pypsa_objective} modeler={modeler_objective} "
-        f"gemspy={gemspy_objective} antares_solver_hybrid={hybrid_objective}"
-    )
-
     assert math.isclose(pypsa_objective, modeler_objective, rel_tol=1e-6)
     assert math.isclose(pypsa_objective, gemspy_objective, rel_tol=1e-6)
     assert math.isclose(pypsa_objective, hybrid_objective, rel_tol=1e-6)
@@ -235,7 +215,6 @@ def test_hybrid_two_scenarios_matches_pypsa_and_gemspy() -> None:
     network.optimize()
     pypsa_objective = network.objective + network.objective_constant
 
-    modeler_objective = _antares_modeler_objective(gems_systems_dir)
     gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=2)
 
     antares_study_dir = gems_dir / AntaresHybridStudyWriter.STUDY_NAME
@@ -245,11 +224,6 @@ def test_hybrid_two_scenarios_matches_pypsa_and_gemspy() -> None:
     )
     hybrid_result_file = _run_hybrid_solver(antares_study_dir)
     hybrid_objective = _weighted_objective(hybrid_result_file, scenario_weights=scenario_weights)
-
-    print(
-        f"pypsa={pypsa_objective} modeler(single-scenario only)={modeler_objective} "
-        f"gemspy={gemspy_objective} antares_solver_hybrid={hybrid_objective}"
-    )
 
     assert math.isclose(pypsa_objective, gemspy_objective, rel_tol=1e-6)
     assert math.isclose(pypsa_objective, hybrid_objective, rel_tol=1e-6)

--- a/tests/e2e/test_hybrid_study_comparison.py
+++ b/tests/e2e/test_hybrid_study_comparison.py
@@ -56,42 +56,66 @@ def check_hybrid_prerequisites() -> None:
         )
 
 
-def _run_hybrid_solver(antares_study_dir: Path) -> Path:
+def _run_hybrid_solver(antares_study_dir: Path) -> list[Path]:
     """
     Step 6 of the trick (see src/antares_hybrid_writer.py's module docstring): run
     antares-solver with no mode flag (generaldata.ini defaults to Economy; there is
-    nothing to expand) and return the resulting simulation_table CSV.
+    nothing to expand) and return every simulation_table CSV under output/.
+
+    Antares emit more than one table (e.g. simulation_table--optim-nb-1/2.csv).
+    Callers must read them all when building the scenario-weighted objective.
     """
     solver_bin = get_antares_solver_bin(PROJECT_ROOT)
     if antares_study_dir.joinpath("output").exists():
         shutil.rmtree(antares_study_dir / "output")
 
-    subprocess.run(
-        [str(solver_bin), "-i", str(antares_study_dir)],
+    completed = subprocess.run(
+        [str(solver_bin), "-i", str(antares_study_dir.resolve())],
         capture_output=True,
         text=True,
         check=False,
         cwd=str(solver_bin.parent),
     )
 
-    result_file = next(antares_study_dir.glob("output/**/simulation_table*"), None)
-    if result_file is None:
+    result_files = list(antares_study_dir.glob("output/**/simulation_table*"))
+    if not result_files:
         raise FileNotFoundError(
             f"No simulation_table found under {antares_study_dir / 'output'}; "
-            "antares-solver likely failed to load the hybrid study, see stdout/stderr above."
+            "antares-solver likely failed to load the hybrid study.\n"
+            f"exit_code={completed.returncode}\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
         )
-    return result_file
+    return result_files
 
 
-def _weighted_objective(simulation_table: Path, scenario_weights: list[float]) -> float:
+def _weighted_objective(simulation_tables: list[Path], scenario_weights: list[float]) -> float:
     """
-    tests.utils.get_objective_value only reads the *first* OBJECTIVE_VALUE row,
-    which is fine for single-scenario runs but not for multi-scenario ones: antares-solver
-    writes one OBJECTIVE_VALUE row per MC year/scenario_index, and they must be
-    combined the same way PyPSA/GemsPy combine them (weighted average).
+    Scenario-weighted objective from all antares-solver simulation tables.
+
+    Each table is read; OBJECTIVE_VALUE
+    rows are collected per scenario_index (duplicate tables / optim-nb passes must
+    agree); then the weighted average over scenarios is returned.
     """
-    df = pd.read_csv(simulation_table, usecols=["output", "scenario_index", "value"])
-    per_scenario = df.query("output == 'OBJECTIVE_VALUE'").set_index("scenario_index")["value"]
+    frames = [pd.read_csv(path, usecols=["output", "scenario_index", "value"]) for path in simulation_tables]
+    objectives = (
+        pd.concat(frames, ignore_index=True)
+        .query("output == 'OBJECTIVE_VALUE'")
+        .groupby("scenario_index", sort=True)["value"]
+        .agg(["min", "max", "first"])
+    )
+    inconsistent = objectives.index[objectives["min"] != objectives["max"]].tolist()
+    if inconsistent:
+        raise AssertionError(
+            f"Conflicting OBJECTIVE_VALUE across simulation tables for scenario_index={inconsistent}: "
+            f"{objectives.loc[inconsistent].to_dict()}"
+        )
+    if list(objectives.index) != list(range(len(scenario_weights))):
+        raise AssertionError(
+            f"Expected OBJECTIVE_VALUE for scenario_index 0..{len(scenario_weights) - 1}, "
+            f"got {list(objectives.index)} from {[p.name for p in simulation_tables]}"
+        )
+    per_scenario = objectives["first"]
     return float(sum(per_scenario[i] * scenario_weights[i] for i in range(len(scenario_weights))))
 
 
@@ -111,68 +135,7 @@ def _gemspy_objective(gems_systems_dir: Path, n_scenarios: int) -> float:
     return float(problem.objective_value)
 
 
-def test_hybrid_two_scenarios_matches_pypsa_and_gemspy() -> None:
-    """
-    Two-scenario (stochastic) network: pypsa / gemspy / antares-solver (hybrid
-    trick) must agree on the scenario-weighted objective.
-
-    Unlike the deterministic baseline above, this study IS multi-scenario and
-    non-investment, so `PyPSAStudyConverter.to_gems_study()` builds the hybrid study
-    automatically -- this test uses that auto-built study directly (no manual
-    `AntaresHybridStudyWriter` call), proving the production wiring itself works.
-
-    antares-modeler alone is deliberately NOT asserted equal here: invoked directly
-    (without the hybrid trick) it only ever solves one scenario -- this is exactly
-    the multi-scenario gap the hybrid trick exists to validate (see
-    src/antares_hybrid_writer.py's module docstring). It is still computed and
-    printed for visibility.
-    """
-    study_name = "test_hybrid_two_scenarios"
-    gems_dir = PROJECT_ROOT / "tmp" / study_name
-    scenario_weights = [0.5, 0.5]
-
-    network = Network(name="HybridTwoScenarios", snapshots=list(range(HOURS_PER_WEEK)))
-    network.add("Bus", "town", v_nom=1)
-    network.add("Load", "load1", bus="town", p_set=[80 + (i % 24) for i in range(HOURS_PER_WEEK)], q_set=0)
-    network.add("Generator", "gen1", bus="town", p_nom_extendable=False, marginal_cost=50, p_nom=200)
-    network.add(
-        "Generator",
-        "gen2",
-        bus="town",
-        p_nom_extendable=False,
-        marginal_cost=10,
-        p_nom=50,
-        p_max_pu=[0.9] * HOURS_PER_WEEK,
-    )
-    network.set_scenarios({"low": 0.5, "high": 0.5})
-    # Static (non-time-series) per-scenario overrides are collapsed to a single value
-    # by the converter today (see gems_model_builder.py's first_per_component logic),
-    # so the scenario axis must be exercised through a genuinely time-varying
-    # attribute: gen2's availability differs per scenario.
-    network.generators_t.p_max_pu[("low", "gen2")] = [1.0] * HOURS_PER_WEEK
-    network.generators_t.p_max_pu[("high", "gen2")] = [0.2] * HOURS_PER_WEEK
-
-    PyPSAStudyConverter(pypsa_network=network, study_dir=gems_dir, series_file_format=".tsv").to_gems_study()
-    gems_systems_dir = gems_dir / "systems"
-
-    network.optimize()
-    pypsa_objective = network.objective + network.objective_constant
-
-    gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=2)
-
-    antares_study_dir = gems_dir / network.name
-    assert antares_study_dir.is_dir(), (
-        "to_gems_study() should have auto-built the antares-solver hybrid study "
-        "for this multi-scenario, non-investment network by default"
-    )
-    hybrid_result_file = _run_hybrid_solver(antares_study_dir)
-    hybrid_objective = _weighted_objective(hybrid_result_file, scenario_weights=scenario_weights)
-
-    assert math.isclose(pypsa_objective, gemspy_objective, rel_tol=1e-6)
-    assert math.isclose(pypsa_objective, hybrid_objective, rel_tol=1e-6)
-
-
-@pytest.mark.parametrize("n_scenarios", [3, 6])
+@pytest.mark.parametrize("n_scenarios", [2, 3, 6])
 def test_hybrid_n_scenarios_matches_pypsa_and_gemspy(n_scenarios: int) -> None:
     """Same hybrid cross-check as the two-scenario test, parametrized for 3 and 6
     equal-weight scenarios (GemsPy currently requires equal weights)."""
@@ -214,8 +177,64 @@ def test_hybrid_n_scenarios_matches_pypsa_and_gemspy(n_scenarios: int) -> None:
         "to_gems_study() should have auto-built the antares-solver hybrid study "
         "for this multi-scenario, non-investment network by default"
     )
-    hybrid_result_file = _run_hybrid_solver(antares_study_dir)
-    hybrid_objective = _weighted_objective(hybrid_result_file, scenario_weights=scenario_weights)
+    hybrid_result_files = _run_hybrid_solver(antares_study_dir)
+    hybrid_objective = _weighted_objective(hybrid_result_files, scenario_weights=scenario_weights)
+
+    assert math.isclose(pypsa_objective, gemspy_objective, rel_tol=1e-6)
+    assert math.isclose(pypsa_objective, hybrid_objective, rel_tol=1e-6)
+
+
+def test_hybrid_distinct_scenario_timeseries_matches_pypsa_and_gemspy() -> None:
+    """
+    Multi-scenario hybrid check where each scenario has a *different* time-series
+    shape (not just a different constant availability): load profiles and gen2
+    availability patterns are anti-correlated across scenarios so that mixing up
+    MC-year data-series columns would change the objective.
+    """
+    study_name = "test_hybrid_distinct_scenario_timeseries"
+    gems_dir = PROJECT_ROOT / "tmp" / study_name
+    scenario_weights = [0.5, 0.5]
+    hours = list(range(HOURS_PER_WEEK))
+
+    # Scenario "day": daytime-heavy load, cheap gen available only in daytime.
+    # Scenario "night": nighttime-heavy load, cheap gen available only at night.
+    day_load = [120.0 if 8 <= (h % 24) < 20 else 40.0 for h in hours]
+    night_load = [40.0 if 8 <= (h % 24) < 20 else 120.0 for h in hours]
+    day_availability = [1.0 if 8 <= (h % 24) < 20 else 0.0 for h in hours]
+    night_availability = [0.0 if 8 <= (h % 24) < 20 else 1.0 for h in hours]
+
+    network = Network(name="HybridDistinctTimeseries", snapshots=hours)
+    network.add("Bus", "town", v_nom=1)
+    network.add("Load", "load1", bus="town", p_set=day_load, q_set=0)
+    network.add("Generator", "gen1", bus="town", p_nom_extendable=False, marginal_cost=50, p_nom=200)
+    network.add(
+        "Generator",
+        "gen2",
+        bus="town",
+        p_nom_extendable=False,
+        marginal_cost=10,
+        p_nom=80,
+        p_max_pu=[0.5] * HOURS_PER_WEEK,
+    )
+    network.set_scenarios({"day": 0.5, "night": 0.5})
+    network.loads_t.p_set[("day", "load1")] = day_load
+    network.loads_t.p_set[("night", "load1")] = night_load
+    network.generators_t.p_max_pu[("day", "gen2")] = day_availability
+    network.generators_t.p_max_pu[("night", "gen2")] = night_availability
+
+    PyPSAStudyConverter(pypsa_network=network, study_dir=gems_dir, series_file_format=".tsv").to_gems_study()
+    gems_systems_dir = gems_dir / "systems"
+
+    network.optimize()
+    pypsa_objective = network.objective + network.objective_constant
+
+    gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=2)
+    antares_study_dir = gems_dir / network.name
+    assert antares_study_dir.is_dir()
+
+    hybrid_result_files = _run_hybrid_solver(antares_study_dir)
+    assert len(hybrid_result_files) >= 1
+    hybrid_objective = _weighted_objective(hybrid_result_files, scenario_weights=scenario_weights)
 
     assert math.isclose(pypsa_objective, gemspy_objective, rel_tol=1e-6)
     assert math.isclose(pypsa_objective, hybrid_objective, rel_tol=1e-6)

--- a/tests/e2e/test_hybrid_study_comparison.py
+++ b/tests/e2e/test_hybrid_study_comparison.py
@@ -38,7 +38,6 @@ from gems_runner.simulation.optimization import build_problem
 from gems_runner.simulation.time_block import TimeBlock
 from pypsa import Network
 
-from src.antares_hybrid_writer import AntaresHybridStudyWriter
 from src.dependencies import get_antares_dir_name, get_antares_solver_bin
 from src.pypsa_converter import PyPSAStudyConverter
 
@@ -161,7 +160,7 @@ def test_hybrid_two_scenarios_matches_pypsa_and_gemspy() -> None:
 
     gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=2)
 
-    antares_study_dir = gems_dir / AntaresHybridStudyWriter.study_name
+    antares_study_dir = gems_dir / network.name
     assert antares_study_dir.is_dir(), (
         "to_gems_study() should have auto-built the antares-solver hybrid study "
         "for this multi-scenario, non-investment network by default"
@@ -210,8 +209,7 @@ def test_hybrid_n_scenarios_matches_pypsa_and_gemspy(n_scenarios: int) -> None:
     pypsa_objective = network.objective + network.objective_constant
 
     gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=n_scenarios)
-
-    antares_study_dir = gems_dir / AntaresHybridStudyWriter.study_name
+    antares_study_dir = gems_dir / network.name
     assert antares_study_dir.is_dir(), (
         "to_gems_study() should have auto-built the antares-solver hybrid study "
         "for this multi-scenario, non-investment network by default"

--- a/tests/e2e/test_hybrid_study_comparison.py
+++ b/tests/e2e/test_hybrid_study_comparison.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Cross-checks PyPSA / GemsPy / Antares Modeler / Antares Solver on the same converted
+GEMS study, using the antares-solver hybrid-study trick implemented in
+`src/antares_hybrid_writer.py` (see that module's docstring for the full rationale:
+why antares-modeler alone can't solve more than scenario 0, why a bare classic Antares
+study with one inert virtual area unlocks antares-solver's Monte-Carlo-year loop, and
+why optim-config.yml/system.yml/modeler-scenariobuilder.dat need patching).
+
+`PyPSAStudyConverter.to_gems_study()` now builds this hybrid study automatically for
+any multi-scenario, non-investment study (see `_has_extendable_capacity` there) --
+`test_hybrid_two_scenarios_matches_pypsa_and_gemspy` below exercises exactly that
+automatic path. The single-scenario baseline test builds it manually via
+`AntaresHybridStudyWriter` directly, since the converter only triggers it for genuine
+multi-scenario studies.
+"""
+
+import math
+import shutil
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from gems_craft.optim_config.parsing import OptimConfig, validate_optim_config
+from gems_craft.study.folder import load_study
+from gems_runner.simulation.optimization import build_problem
+from gems_runner.simulation.time_block import TimeBlock
+from pypsa import Network
+
+from src.antares_hybrid_writer import AntaresHybridStudyWriter
+from src.dependencies import get_antares_dir_name, get_antares_modeler_bin, get_antares_solver_bin
+from src.pypsa_converter import PyPSAStudyConverter
+from tests.utils import get_objective_value
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+HOURS_PER_WEEK = 168
+
+
+def _antares_craft_available() -> bool:
+    try:
+        import antares.craft  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.fixture(autouse=True)
+def check_hybrid_prerequisites() -> None:
+    """Skip (rather than fail) when the Antares binaries or antares-craft aren't available."""
+    if not (PROJECT_ROOT / get_antares_dir_name()).is_dir():
+        pytest.skip(
+            f"Antares binaries not found. Please download version from "
+            f"https://github.com/AntaresSimulatorTeam/Antares_Simulator/releases into {PROJECT_ROOT}"
+        )
+    if not _antares_craft_available():
+        pytest.skip("antares-craft is not installed (needed to build the hybrid-study trick).")
+
+
+def _run_hybrid_solver(antares_study_dir: Path) -> Path:
+    """Step 6 of the trick (see src/antares_hybrid_writer.py's module docstring): run
+    antares-solver with no mode flag (generaldata.ini defaults to Economy; there is
+    nothing to expand) and return the resulting simulation_table CSV."""
+    solver_bin = get_antares_solver_bin(PROJECT_ROOT)
+    if antares_study_dir.joinpath("output").exists():
+        shutil.rmtree(antares_study_dir / "output")
+
+    result = subprocess.run(
+        [str(solver_bin), "-i", str(antares_study_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(solver_bin.parent),
+    )
+    print("================================")
+    print("Antares solver (hybrid) output: returncode=%s" % result.returncode)
+    print("stdout:", result.stdout)
+    print("stderr:", result.stderr)
+    print("================================")
+
+    result_file = next(antares_study_dir.glob("output/**/simulation_table*"), None)
+    if result_file is None:
+        raise FileNotFoundError(
+            f"No simulation_table found under {antares_study_dir / 'output'}; "
+            "antares-solver likely failed to load the hybrid study, see stdout/stderr above."
+        )
+    return result_file
+
+
+def _weighted_objective(simulation_table: Path, scenario_weights: list[float]) -> float:
+    """`tests.utils.get_objective_value` only reads the *first* OBJECTIVE_VALUE row,
+    which is fine for single-scenario runs but not for multi-scenario ones: antares-solver
+    writes one OBJECTIVE_VALUE row per MC year/scenario_index, and they must be
+    combined the same way PyPSA/GemsPy combine them (weighted average)."""
+    df = pd.read_csv(simulation_table, usecols=["output", "scenario_index", "value"])
+    per_scenario = df.query("output == 'OBJECTIVE_VALUE'").set_index("scenario_index")["value"]
+    return float(sum(per_scenario[i] * scenario_weights[i] for i in range(len(scenario_weights))))
+
+
+def _gemspy_objective(gems_systems_dir: Path, n_scenarios: int) -> float:
+    gemspy_study = load_study(gems_systems_dir)
+    optim_config = OptimConfig()
+    optim_config.time_scope.first_time_step = 0
+    optim_config.time_scope.last_time_step = HOURS_PER_WEEK - 1
+    optim_config.scenario_scope.include = list(range(n_scenarios))
+    validate_optim_config(optim_config, gemspy_study.system)
+
+    timesteps = list(range(HOURS_PER_WEEK))
+    block = TimeBlock(0, timesteps)
+    scenario_ids = optim_config.scenario_scope.scenario_ids
+    problem = build_problem(gemspy_study, block, scenario_ids, optim_config=optim_config)
+    problem.solve(solver_name=optim_config.solver_options.name, **optim_config.solver_options.parsed_parameters())
+    return float(problem.objective_value)
+
+
+def _antares_modeler_objective(gems_systems_dir: Path) -> float:
+    """Direct antares-modeler invocation, same pattern as end_2_end_tests.py's
+    get_gems_study_objective(). Note: this only ever solves ONE scenario -- see
+    module docstring -- so it is only compared for the deterministic fixture."""
+    antares_modeler_bin = get_antares_modeler_bin(PROJECT_ROOT)
+    if (gems_systems_dir / "output").exists():
+        shutil.rmtree(gems_systems_dir / "output")
+
+    subprocess.run(
+        [str(antares_modeler_bin), str(gems_systems_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(antares_modeler_bin.parent),
+    )
+    result_file = next(gems_systems_dir.glob("output/**/simulation_table*"), None)
+    if result_file is None:
+        raise FileNotFoundError(f"No simulation_table found under {gems_systems_dir / 'output'}")
+    return get_objective_value(result_file)
+
+
+def test_hybrid_deterministic_matches_all_execution_paths() -> None:
+    """Single-scenario network: pypsa / antares-modeler / gemspy / antares-solver
+    (hybrid trick) must all agree exactly.
+
+    The converter itself only auto-builds the hybrid study for genuine multi-scenario
+    studies (see `PyPSAStudyConverter.to_gems_study`), so this baseline calls
+    `AntaresHybridStudyWriter` directly to confirm the trick introduces no bias before
+    checking real multi-scenario behaviour below.
+    """
+    study_name = "test_hybrid_deterministic"
+    gems_dir = PROJECT_ROOT / "tmp" / study_name
+
+    network = Network(name="HybridDeterministic", snapshots=list(range(HOURS_PER_WEEK)))
+    network.add("Bus", "town", v_nom=1)
+    network.add("Load", "load1", bus="town", p_set=[80 + (i % 24) for i in range(HOURS_PER_WEEK)], q_set=0)
+    network.add("Generator", "gen1", bus="town", p_nom_extendable=False, marginal_cost=50, p_nom=200)
+    network.add("Generator", "gen2", bus="town", p_nom_extendable=False, marginal_cost=10, p_nom=50)
+
+    PyPSAStudyConverter(pypsa_network=network, study_dir=gems_dir, series_file_format=".tsv").to_gems_study()
+    gems_systems_dir = gems_dir / "systems"
+
+    network.optimize()
+    pypsa_objective = network.objective + network.objective_constant
+
+    modeler_objective = _antares_modeler_objective(gems_systems_dir)
+    gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=1)
+
+    antares_study_dir = AntaresHybridStudyWriter(gems_dir).write(
+        gems_systems_dir=gems_systems_dir, pypsa_network=network, n_scenarios=1
+    )
+    hybrid_result_file = _run_hybrid_solver(antares_study_dir)
+    hybrid_objective = _weighted_objective(hybrid_result_file, scenario_weights=[1.0])
+
+    print(
+        f"pypsa={pypsa_objective} modeler={modeler_objective} "
+        f"gemspy={gemspy_objective} antares_solver_hybrid={hybrid_objective}"
+    )
+
+    assert math.isclose(pypsa_objective, modeler_objective, rel_tol=1e-6)
+    assert math.isclose(pypsa_objective, gemspy_objective, rel_tol=1e-6)
+    assert math.isclose(pypsa_objective, hybrid_objective, rel_tol=1e-6)
+
+
+def test_hybrid_two_scenarios_matches_pypsa_and_gemspy() -> None:
+    """Two-scenario (stochastic) network: pypsa / gemspy / antares-solver (hybrid
+    trick) must agree on the scenario-weighted objective.
+
+    Unlike the deterministic baseline above, this study IS multi-scenario and
+    non-investment, so `PyPSAStudyConverter.to_gems_study()` builds the hybrid study
+    automatically -- this test uses that auto-built study directly (no manual
+    `AntaresHybridStudyWriter` call), proving the production wiring itself works.
+
+    antares-modeler alone is deliberately NOT asserted equal here: invoked directly
+    (without the hybrid trick) it only ever solves one scenario -- this is exactly
+    the multi-scenario gap the hybrid trick exists to validate (see
+    src/antares_hybrid_writer.py's module docstring). It is still computed and
+    printed for visibility.
+    """
+    study_name = "test_hybrid_two_scenarios"
+    gems_dir = PROJECT_ROOT / "tmp" / study_name
+    scenario_weights = [0.5, 0.5]
+
+    network = Network(name="HybridTwoScenarios", snapshots=list(range(HOURS_PER_WEEK)))
+    network.add("Bus", "town", v_nom=1)
+    network.add("Load", "load1", bus="town", p_set=[80 + (i % 24) for i in range(HOURS_PER_WEEK)], q_set=0)
+    network.add("Generator", "gen1", bus="town", p_nom_extendable=False, marginal_cost=50, p_nom=200)
+    network.add(
+        "Generator",
+        "gen2",
+        bus="town",
+        p_nom_extendable=False,
+        marginal_cost=10,
+        p_nom=50,
+        p_max_pu=[0.9] * HOURS_PER_WEEK,
+    )
+    network.set_scenarios({"low": 0.5, "high": 0.5})
+    # Static (non-time-series) per-scenario overrides are collapsed to a single value
+    # by the converter today (see gems_model_builder.py's first_per_component logic),
+    # so the scenario axis must be exercised through a genuinely time-varying
+    # attribute: gen2's availability differs per scenario.
+    network.generators_t.p_max_pu[("low", "gen2")] = [1.0] * HOURS_PER_WEEK
+    network.generators_t.p_max_pu[("high", "gen2")] = [0.2] * HOURS_PER_WEEK
+
+    PyPSAStudyConverter(pypsa_network=network, study_dir=gems_dir, series_file_format=".tsv").to_gems_study()
+    gems_systems_dir = gems_dir / "systems"
+
+    network.optimize()
+    pypsa_objective = network.objective + network.objective_constant
+
+    modeler_objective = _antares_modeler_objective(gems_systems_dir)
+    gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=2)
+
+    antares_study_dir = gems_dir / AntaresHybridStudyWriter.STUDY_NAME
+    assert antares_study_dir.is_dir(), (
+        "to_gems_study() should have auto-built the antares-solver hybrid study "
+        "for this multi-scenario, non-investment network by default"
+    )
+    hybrid_result_file = _run_hybrid_solver(antares_study_dir)
+    hybrid_objective = _weighted_objective(hybrid_result_file, scenario_weights=scenario_weights)
+
+    print(
+        f"pypsa={pypsa_objective} modeler(single-scenario only)={modeler_objective} "
+        f"gemspy={gemspy_objective} antares_solver_hybrid={hybrid_objective}"
+    )
+
+    assert math.isclose(pypsa_objective, gemspy_objective, rel_tol=1e-6)
+    assert math.isclose(pypsa_objective, hybrid_objective, rel_tol=1e-6)
+
+
+def test_unequal_scenario_weights_are_rejected() -> None:
+    """Multi-scenario studies with UNEQUAL scenario weights (0.1 / 0.9) must be
+    rejected at conversion time with a clear error, rather than silently producing a
+    GEMS study whose GemsPy/antares-modeler results don't match PyPSA's.
+
+    This is a real gap, not a hypothetical one: GemsPy's `expec()` operator (see the
+    "Expectation semantics (average over scenarios) are applied automatically"
+    UserWarning emitted during model resolution) currently computes a plain,
+    UNWEIGHTED arithmetic mean across scenarios -- it does not consume PyPSA's
+    scenario_weightings at all. With equal weights (0.5/0.5, see
+    `test_hybrid_two_scenarios_matches_pypsa_and_gemspy` above) the unweighted and
+    true weighted average coincide, so results are correct; with unequal weights
+    (e.g. 0.1/0.9 here) they silently diverge:
+      - pypsa's true weighted objective:  0.1 * 432600 + 0.9 * 701400 = 674520.0
+      - gemspy's unweighted average:       (432600 + 701400) / 2      = 567000.0
+    `PyPSAStudyConverter._validate_scenario_weightings` fails fast on construction
+    instead, until GemsPy's `expec()` supports per-scenario weights.
+    """
+    study_name = "test_unequal_scenario_weights"
+    gems_dir = PROJECT_ROOT / "tmp" / study_name
+
+    network = Network(name="HybridUnequalWeights", snapshots=list(range(HOURS_PER_WEEK)))
+    network.add("Bus", "town", v_nom=1)
+    network.add("Load", "load1", bus="town", p_set=[80 + (i % 24) for i in range(HOURS_PER_WEEK)], q_set=0)
+    network.add("Generator", "gen1", bus="town", p_nom_extendable=False, marginal_cost=50, p_nom=200)
+    network.add(
+        "Generator",
+        "gen2",
+        bus="town",
+        p_nom_extendable=False,
+        marginal_cost=10,
+        p_nom=50,
+        p_max_pu=[0.9] * HOURS_PER_WEEK,
+    )
+    network.set_scenarios({"low": 0.1, "high": 0.9})
+    network.generators_t.p_max_pu[("low", "gen2")] = [1.0] * HOURS_PER_WEEK
+    network.generators_t.p_max_pu[("high", "gen2")] = [0.2] * HOURS_PER_WEEK
+
+    with pytest.raises(ValueError, match="same weight"):
+        PyPSAStudyConverter(pypsa_network=network, study_dir=gems_dir, series_file_format=".tsv")

--- a/tests/e2e/test_hybrid_study_comparison.py
+++ b/tests/e2e/test_hybrid_study_comparison.py
@@ -20,10 +20,9 @@ why optim-config.yml/system.yml/modeler-scenariobuilder.dat need patching).
 
 `PyPSAStudyConverter.to_gems_study()` now builds this hybrid study automatically for
 any multi-scenario, non-investment study (see `_has_extendable_capacity` there) --
-`test_hybrid_two_scenarios_matches_pypsa_and_gemspy` below exercises exactly that
-automatic path. The single-scenario baseline test builds it manually via
-`AntaresHybridStudyWriter` directly, since the converter only triggers it for genuine
-multi-scenario studies.
+`test_hybrid_two_scenarios_matches_pypsa_and_gemspy` and the parametrized
+`test_hybrid_n_scenarios_matches_pypsa_and_gemspy` (3 / 6 scenarios) exercise that
+automatic path.
 """
 
 import math
@@ -161,6 +160,56 @@ def test_hybrid_two_scenarios_matches_pypsa_and_gemspy() -> None:
     pypsa_objective = network.objective + network.objective_constant
 
     gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=2)
+
+    antares_study_dir = gems_dir / AntaresHybridStudyWriter.study_name
+    assert antares_study_dir.is_dir(), (
+        "to_gems_study() should have auto-built the antares-solver hybrid study "
+        "for this multi-scenario, non-investment network by default"
+    )
+    hybrid_result_file = _run_hybrid_solver(antares_study_dir)
+    hybrid_objective = _weighted_objective(hybrid_result_file, scenario_weights=scenario_weights)
+
+    assert math.isclose(pypsa_objective, gemspy_objective, rel_tol=1e-6)
+    assert math.isclose(pypsa_objective, hybrid_objective, rel_tol=1e-6)
+
+
+@pytest.mark.parametrize("n_scenarios", [3, 6])
+def test_hybrid_n_scenarios_matches_pypsa_and_gemspy(n_scenarios: int) -> None:
+    """Same hybrid cross-check as the two-scenario test, parametrized for 3 and 6
+    equal-weight scenarios (GemsPy currently requires equal weights)."""
+    study_name = f"test_hybrid_{n_scenarios}_scenarios"
+    gems_dir = PROJECT_ROOT / "tmp" / study_name
+    weight = 1.0 / n_scenarios
+    scenario_weights = [weight] * n_scenarios
+    scenarios = {f"s{i}": weight for i in range(n_scenarios)}
+
+    network = Network(name=f"Hybrid{n_scenarios}Scenarios", snapshots=list(range(HOURS_PER_WEEK)))
+    network.add("Bus", "town", v_nom=1)
+    network.add("Load", "load1", bus="town", p_set=[80 + (i % 24) for i in range(HOURS_PER_WEEK)], q_set=0)
+    network.add("Generator", "gen1", bus="town", p_nom_extendable=False, marginal_cost=50, p_nom=200)
+    network.add(
+        "Generator",
+        "gen2",
+        bus="town",
+        p_nom_extendable=False,
+        marginal_cost=10,
+        p_nom=50,
+        p_max_pu=[0.9] * HOURS_PER_WEEK,
+    )
+    network.set_scenarios(scenarios)
+    # Distinct per-scenario availability so the scenario axis is exercised (see
+    # comment in test_hybrid_two_scenarios_matches_pypsa_and_gemspy).
+    for i in range(n_scenarios):
+        availability = 1.0 - 0.8 * i / (n_scenarios - 1)
+        network.generators_t.p_max_pu[(f"s{i}", "gen2")] = [availability] * HOURS_PER_WEEK
+
+    PyPSAStudyConverter(pypsa_network=network, study_dir=gems_dir, series_file_format=".tsv").to_gems_study()
+    gems_systems_dir = gems_dir / "systems"
+
+    network.optimize()
+    pypsa_objective = network.objective + network.objective_constant
+
+    gemspy_objective = _gemspy_objective(gems_systems_dir, n_scenarios=n_scenarios)
 
     antares_study_dir = gems_dir / AntaresHybridStudyWriter.study_name
     assert antares_study_dir.is_dir(), (

--- a/tests/local_benchmark/benchmark.py
+++ b/tests/local_benchmark/benchmark.py
@@ -21,11 +21,11 @@ from pathlib import Path
 import pandas as pd
 import pytest
 import yaml
-from gems.optim_config.parsing import OptimConfig, validate_optim_config
-from gems.simulation.optimization import build_problem
-from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.simulation.time_block import TimeBlock
-from gems.study.folder import load_study
+from gems_craft.optim_config.parsing import OptimConfig, validate_optim_config
+from gems_craft.study.folder import load_study
+from gems_runner.simulation.optimization import build_problem
+from gems_runner.simulation.simulation_table import SimulationTableBuilder
+from gems_runner.simulation.time_block import TimeBlock
 
 from src.dependencies import get_antares_dir_name, get_antares_modeler_bin, get_antares_version
 from src.pypsa_converter import PyPSAStudyConverter

--- a/tests/unit_tests/test_write_and_register_time_series.py
+++ b/tests/unit_tests/test_write_and_register_time_series.py
@@ -71,10 +71,13 @@ def base_network() -> Network:
 
 @pytest.fixture()
 def scenario_network(base_network: Network) -> Network:
+    # Equal weights: PyPSAStudyConverter requires every scenario to carry the same
+    # weight (see PyPSAStudyConverter._validate_scenario_weightings) -- this test only
+    # exercises data-series writing/registration, not weight-dependent results.
     scenarios = {
-        "low": 0.3,
-        "medium": 0.5,
-        "high": 0.2,
+        "low": 1 / 3,
+        "medium": 1 / 3,
+        "high": 1 / 3,
     }
 
     if hasattr(base_network, "has_scenarios"):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -415,7 +415,9 @@ def analyze_benchmark_study(row_number: int, results_file: Path | None = None) -
     antares_modeler_pie_colors = ["#2e86ab", "steelblue", "coral", "#f18f01"]
     # Only include non-zero slices
     filtered = [
-        (lbl, v, c) for lbl, v, c in zip(antares_modeler_pie_labels, antares_modeler_pie_vals, antares_modeler_pie_colors) if v > 0
+        (lbl, v, c)
+        for lbl, v, c in zip(antares_modeler_pie_labels, antares_modeler_pie_vals, antares_modeler_pie_colors)
+        if v > 0
     ]
     if filtered:
         f_labels, f_vals, f_colors = zip(*filtered)

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,53 @@ wheels = [
 ]
 
 [[package]]
+name = "antares-craft"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antares-study-version" },
+    { name = "antares-timeseries-generation" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "polars" },
+    { name = "psutil" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/22/c4b801b8a0d87a0092ac582d315b03c20c41e8cbcdd5dad7b5683880b90a/antares_craft-0.15.1.tar.gz", hash = "sha256:0e4422ec0d83027375b02dc43ff4f881c3e3ac012949a1c5bf51e7227b94d28c", size = 169034, upload-time = "2026-07-10T15:42:20.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/99/05c8e96951e814b74d2425fa1aeefdab458379bd2bf0ec82ca47de7c529e/antares_craft-0.15.1-py3-none-any.whl", hash = "sha256:be3ed9708513f0ba75e61a1599d18f29e5500c9bd5d58f17c32e148b44b1ce1c", size = 245031, upload-time = "2026-07-10T15:42:19.378Z" },
+]
+
+[[package]]
+name = "antares-study-version"
+version = "1.0.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e3/745bc7ce527a0b2a639f9d04fde47e19a779dc6ebc6bed892459d1c58dc6/antares_study_version-1.0.20.tar.gz", hash = "sha256:a598a82c2e4373240ee36ac6e3a90fde43a898038193a3265240b276d779656e", size = 881716, upload-time = "2025-07-31T09:31:08.754Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/c9/0d8213316e186684ef6c66e7cd1bf74febc72026219be6b28537b549e52c/antares_study_version-1.0.20-py3-none-any.whl", hash = "sha256:cf37e2aeb0f06236bc619e5f6919e691e42307beff29800f735e9ae1d0c5fcc4", size = 1746991, upload-time = "2025-07-31T09:31:06.97Z" },
+]
+
+[[package]]
+name = "antares-timeseries-generation"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/6e/b59a4f1c6f24ff1d32d40cc58184a7b5e14f187f119f3f7ce076ea6a9946/antares_timeseries_generation-0.1.9.tar.gz", hash = "sha256:0c19a3f56e424ac3105686691ff1d1ef6c0320244af986e852698dc9b71619c6", size = 21504, upload-time = "2025-12-04T16:31:35.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e4/a81417ac4ac1607aab01b5e91f5de9d202688348d5af687aa4629d7367ff/antares_timeseries_generation-0.1.9-py3-none-any.whl", hash = "sha256:e69799290b9f29e8ed2ebc6ad49ce128a8559fc4af5804428eb620801295e4c4", size = 20185, upload-time = "2025-12-04T16:31:35.008Z" },
+]
+
+[[package]]
 name = "antlr4-python3-runtime"
 version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -164,6 +211,80 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/6c/0971e602c1390a423e6621dfbad9f1d375186bdaf9c9c7f75e06f1fbf355/cftime-1.6.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19cbfc5152fb0b34ce03acf9668229af388d7baa63a78f936239cb011ccbe6b1", size = 1555894, upload-time = "2026-01-02T20:45:16.351Z" },
     { url = "https://files.pythonhosted.org/packages/ad/fc/8475a15b7c3209a4a68b563dfc5e01ce74f2d8b9822372c3d30c68ab7f39/cftime-1.6.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4470cd5ef3c2514566f53efbcbb64dd924fa0584637d90285b2f983bd4ee7d97", size = 513027, upload-time = "2026-01-02T20:45:20.023Z" },
     { url = "https://files.pythonhosted.org/packages/f7/80/4ecbda8318fbf40ad4e005a4a93aebba69e81382e5b4c6086251cd5d0ee8/cftime-1.6.5-cp314-cp314t-win_arm64.whl", hash = "sha256:034c15a67144a0a5590ef150c99f844897618b148b87131ed34fda7072614662", size = 469065, upload-time = "2026-01-02T20:45:23.398Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -405,7 +526,7 @@ wheels = [
 
 [[package]]
 name = "gemspy"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
@@ -419,9 +540,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/8a/4e4285e61e9d6716a19995cf0680373a7ec6dd573a659101b4c61d75043b/gemspy-0.1.2.tar.gz", hash = "sha256:55aeef7ac32f049136d82381d488e03744329ef95489f2562f3cd14b11193487", size = 88370, upload-time = "2026-06-11T12:13:17.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/e2/8260139805f657cdd5dd2d5f3e02c974c05e4cd3ac83724b6b759c488892/gemspy-0.1.3.tar.gz", hash = "sha256:49325e19f37be1f1b1dc394fab4f29d85b813a95256a5da62756936100c5341a", size = 90736, upload-time = "2026-07-24T09:54:41.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/a5/592b323148996541f80e4e812dddf92982d340afe5e14a765b62b590312c/gemspy-0.1.2-py3-none-any.whl", hash = "sha256:dd4b7b8adb9dfde1e00717f0c92df77725701b9b8bf2e5cc796a03cb594e1c65", size = 114582, upload-time = "2026-06-11T12:13:16.801Z" },
+    { url = "https://files.pythonhosted.org/packages/95/d4/208b59a521ba66f75de1e5757401ce029469e4d537ff559602d670f641b3/gemspy-0.1.3-py3-none-any.whl", hash = "sha256:115dd4b344551ab3e4f6cadc68328e9926d01f1297fe1227e25c61b34aebf0bd", size = 120811, upload-time = "2026-07-24T09:54:40.693Z" },
 ]
 
 [[package]]
@@ -499,6 +620,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1363,6 +1493,34 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "py"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1703,6 +1861,7 @@ name = "pypsa-to-gems-converter"
 version = "0.0.2"
 source = { editable = "." }
 dependencies = [
+    { name = "antares-craft" },
     { name = "pandas" },
     { name = "polars" },
     { name = "pyarrow" },
@@ -1726,6 +1885,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "antares-craft", specifier = "==0.15.1" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "polars", specifier = ">=0.20.0" },
     { name = "pyarrow" },
@@ -1736,7 +1896,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "gemspy", specifier = "==0.1.2" },
+    { name = "gemspy", specifier = "==0.1.3" },
     { name = "highspy", specifier = ">=1.5.0" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pandas-stubs", specifier = ">=2.0.0" },
@@ -1925,6 +2085,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/9f/a3635cc4ec8fc6e14b46e7db1f7f8763d8c4bef33dcc124eea2e6cb2c8f3/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f4a8f5cc84c7ad6bffa0e9947b33eb343ad66e6b53e94fe54378a5508c5ed53", size = 1348524, upload-time = "2026-04-07T11:16:23.451Z" },
     { url = "https://files.pythonhosted.org/packages/cc/1b/2b229520f0b48464cfcd7aa758f74551d12c9bc4ab544022a60210aab064/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c6d85283629646fa87acc22c66b30ea9d4de7f6fdf887daa2e30fa041829b5", size = 3099302, upload-time = "2026-04-07T11:16:25.858Z" },
     { url = "https://files.pythonhosted.org/packages/aa/b5/363906b1064fc6fe611783a61764927bbd91919aaaabe8cba82151ca93ef/rapidfuzz-3.14.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:dfef96543ced67d9513a422755db422ae1dc34dade0a1485e0b43e7342ed3ebf", size = 1509889, upload-time = "2026-04-07T11:16:28.487Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -2187,6 +2362,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Process ID

<!-- Which governance process does this PR fall under? -->
<!-- P2G-01 | P2G-02 | P2G-03 | N/A -->

**Process:**

## Description

<!-- What does this PR change and why? -->
Integrate "trick"(see source code comments) for execution of operational(multi scenario) studies 
Validates that we have same results for pypsa,antares and gemspy
Add constraint for weights over scenarios.(because of gemspy)

## Impact Analysis

<!-- Which converter modules, models, or studies are affected? -->
<!-- Are there breaking changes to existing study generation? -->
Now when we convert multi scenario pypsa studies, we need to care that if studies aren't investment we need to have equal weights because otherwise converter will raise error this is not supported because of gemspy behavior. 

## Checklist

- [x] Unit tests pass (`pytest tests/unit_tests/`)
- [x] E2E tests pass (or confirmed not affected)
- [ ] `pyproject.toml` version bumped if converter logic changed
- [ ] Changelog entry added with new version header if library changed (`CHANGELOG-pypsa_models_library.md`)
- [ ] `COMPATIBILITY.md` updated if supported versions changed
- [ ] Documentation updated or confirmed up to date
- [ ] `AGENTS.md` reviewed for impact and updated if needed
